### PR TITLE
add contentInset, contentOffset and scrollIndicatorInsets props

### DIFF
--- a/RNTableView/RNTableView.h
+++ b/RNTableView/RNTableView.h
@@ -33,6 +33,9 @@
 @property (nonatomic) BOOL customCells;
 @property (nonatomic) BOOL editing;
 @property (nonatomic) BOOL emptyInsets;
+@property (nonatomic, assign) UIEdgeInsets contentInset;
+@property (nonatomic, assign) CGPoint contentOffset;
+@property (nonatomic, assign) UIEdgeInsets scrollIndicatorInsets;
 
 @property (nonatomic, assign) UITableViewStyle tableViewStyle;
 @property (nonatomic, assign) UITableViewCellStyle tableViewCellStyle;

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -110,6 +110,9 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     _tableView.delegate = self;
     _tableView.tableFooterView = [[UIView alloc] initWithFrame:CGRectZero];
     _tableView.allowsMultipleSelectionDuringEditing = NO;
+    _tableView.contentInset = self.contentInset;
+    _tableView.contentOffset = self.contentOffset;
+    _tableView.scrollIndicatorInsets = self.scrollIndicatorInsets;
     [self addSubview:_tableView];
 }
 

--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -34,6 +34,9 @@ RCT_EXPORT_VIEW_PROPERTY(cellHeight, float)
 RCT_EXPORT_VIEW_PROPERTY(textColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(tintColor, UIColor)
 RCT_EXPORT_VIEW_PROPERTY(selectedTextColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(contentInset, UIEdgeInsets)
+RCT_EXPORT_VIEW_PROPERTY(contentOffset, CGPoint)
+RCT_EXPORT_VIEW_PROPERTY(scrollIndicatorInsets, UIEdgeInsets)
 
 RCT_CUSTOM_VIEW_PROPERTY(tableViewStyle, UITableViewStyle, RNTableView) {
     [view setTableViewStyle:[RCTConvert NSInteger:json]];

--- a/index.js
+++ b/index.js
@@ -20,7 +20,27 @@ var TableView = React.createClass({
         autoFocus: React.PropTypes.bool,
         json: React.PropTypes.string,
         textColor: React.PropTypes.string,
-        tintColor: React.PropTypes.string
+        tintColor: React.PropTypes.string,
+        /**
+         * The amount by which the content is inset from the edges
+         * of the TableView. Defaults to `{0, 0, 0, 0}`.
+         * @platform ios
+         */
+        contentInset: React.EdgeInsetsPropType,
+        /**
+         * Used to manually set the starting scroll offset.
+         * The default value is `{x: 0, y: 0}`.
+         * @platform ios
+         */
+        contentOffset: React.PointPropType,
+        /**
+         * The amount by which the scroll view indicators are inset from the
+         * edges of the TableView. This should normally be set to the same
+         * value as the `contentInset`. Defaults to `contentInset` or
+         * `{0, 0, 0, 0}`.
+         * @platform ios
+         */
+        scrollIndicatorInsets: React.EdgeInsetsPropType,
     },
 
     getInitialState: function() {
@@ -93,6 +113,7 @@ var TableView = React.createClass({
                     additionalItems={this.state.additionalItems}
                     tableViewStyle={TableView.Consts.Style.Plain}
                     tableViewCellStyle={TableView.Consts.CellStyle.Subtitle}
+                    scrollIndicatorInsets={this.props.contentInset}
                     {...this.props}
                     json={this.state.json}
                     onPress={this._onPress}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tableview",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Native iOS TableView wrapper for React Native",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The React Native ScrollView and ListView components have properties (contentInset, contentOffset and scrollIndicatorInsets) that allow the content to appear below other components like TabBarIOS and a custom NavBar (that shows the contents partially behind it).

The scrollIndicatorInsets prop will default to contentInset if a value is not provided.