### PR TITLE
Adds CocoaPods podspec.

### DIFF
--- a/RNTableView.podspec
+++ b/RNTableView.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+
+  s.name         = "RNTableView"
+  s.version      = "1.4.6"
+  s.homepage     = "https://github.com/aksonov/react-native-tableview"
+  s.platform     = :ios, "7.0"
+  s.source       = { :git => "https://github.com/aksonov/react-native-tableview.git" }
+  s.source_files = 'RNTableView/*.{h,m}'
+  s.preserve_paths = "**/*.js"
+  s.dependency 'React'
+
+end


### PR DESCRIPTION
When using many objc dependencies it's pretty sweet to use CocoaPods. This PR adds the possibility to integrate this project with CocoaPods without having to maintain yet another dependency manager registry. This is also the way React Native core does it. 

**Usage** `Podspec`: 
```
target 'MyApp' do
  source 'https://github.com/CocoaPods/Specs.git'

  pod 'React', :subspecs => ['Core', 'RCTImage', 'RCTNetwork', 'RCTText', 'RCTWebSocket', 'RCTPushNotification'], :path => 'node_modules/react-native'

  pod 'RNTableView', :path => 'node_modules/react-native-tableview'
end

```