### PR TITLE
Fixes conversion type of separatorStyle prop.

### DIFF
--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -54,7 +54,7 @@ RCT_CUSTOM_VIEW_PROPERTY(contentInset, UIEdgeInsets, RNTableView) {
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(separatorStyle, UITableViewCellSeparatorStyle, RNTableView) {
-    [view setSeparatorStyle:[RCTConvert UIEdgeInsets:json]];
+    [view setSeparatorStyle:[RCTConvert NSInteger:json]];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(contentOffset, CGPoint, RNTableView) {


### PR DESCRIPTION
Using master causes my build to fail with RN 0.15 and 0.16. The culprit is [this line](https://github.com/aksonov/react-native-tableview/pull/57/files#diff-0c1a4ccbf0e3642a86b9f624b80f430dR57): 
```
[view setSeparatorStyle:[RCTConvert UIEdgeInsets:json]];
```

This PR changes this to NSInteger instead.