### PR TITLE
enhancement - allow custom reusable cells

### DIFF
--- a/RNTableView.xcodeproj/project.pbxproj
+++ b/RNTableView.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0808A0331C67E9A60038993A /* RNReactModuleCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 0808A0321C67E9A60038993A /* RNReactModuleCell.m */; };
+		084AEF361C6B155900A0A569 /* RNAppGlobals.m in Sources */ = {isa = PBXBuildFile; fileRef = 084AEF351C6B155900A0A569 /* RNAppGlobals.m */; };
 		872545E11BAAC85D00889249 /* JSONDataSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 872545D61BAAC85D00889249 /* JSONDataSource.m */; };
 		872545E21BAAC85D00889249 /* RNCellView.m in Sources */ = {isa = PBXBuildFile; fileRef = 872545D81BAAC85D00889249 /* RNCellView.m */; };
 		872545E31BAAC85D00889249 /* RNCellViewManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 872545DA1BAAC85D00889249 /* RNCellViewManager.m */; };
@@ -32,6 +34,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0808A0311C67E9A60038993A /* RNReactModuleCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNReactModuleCell.h; sourceTree = "<group>"; };
+		0808A0321C67E9A60038993A /* RNReactModuleCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNReactModuleCell.m; sourceTree = "<group>"; };
+		084AEF341C6B155900A0A569 /* RNAppGlobals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNAppGlobals.h; sourceTree = "<group>"; };
+		084AEF351C6B155900A0A569 /* RNAppGlobals.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNAppGlobals.m; sourceTree = "<group>"; };
 		872545D51BAAC85D00889249 /* JSONDataSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSONDataSource.h; sourceTree = "<group>"; };
 		872545D61BAAC85D00889249 /* JSONDataSource.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSONDataSource.m; sourceTree = "<group>"; };
 		872545D71BAAC85D00889249 /* RNCellView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCellView.h; sourceTree = "<group>"; };
@@ -69,6 +75,10 @@
 		872545D41BAAC85D00889249 /* RNTableView */ = {
 			isa = PBXGroup;
 			children = (
+				084AEF341C6B155900A0A569 /* RNAppGlobals.h */,
+				084AEF351C6B155900A0A569 /* RNAppGlobals.m */,
+				0808A0311C67E9A60038993A /* RNReactModuleCell.h */,
+				0808A0321C67E9A60038993A /* RNReactModuleCell.m */,
 				872545D51BAAC85D00889249 /* JSONDataSource.h */,
 				872545D61BAAC85D00889249 /* JSONDataSource.m */,
 				872545D71BAAC85D00889249 /* RNCellView.h */,
@@ -177,11 +187,13 @@
 				872545E31BAAC85D00889249 /* RNCellViewManager.m in Sources */,
 				8799E1E01BF1152400AF9A67 /* RNTableFooterViewManager.m in Sources */,
 				872545E51BAAC85D00889249 /* RNTableViewCell.m in Sources */,
+				0808A0331C67E9A60038993A /* RNReactModuleCell.m in Sources */,
 				8799E1DD1BF114F900AF9A67 /* RNTableFooterView.m in Sources */,
 				8799E1E31BF117F600AF9A67 /* RNTableHeaderView.m in Sources */,
 				8799E1E61BF1181400AF9A67 /* RNTableHeaderViewManager.m in Sources */,
 				872545E61BAAC85D00889249 /* RNTableViewManager.m in Sources */,
 				872545E11BAAC85D00889249 /* JSONDataSource.m in Sources */,
+				084AEF361C6B155900A0A569 /* RNAppGlobals.m in Sources */,
 				872545E41BAAC85D00889249 /* RNTableView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RNTableView/RNAppGlobals.h
+++ b/RNTableView/RNAppGlobals.h
@@ -1,0 +1,13 @@
+
+#import <foundation/Foundation.h>
+@class RCTBridge;
+
+@interface RNAppGlobals : NSObject {
+    RCTBridge *appBridge;
+}
+
+@property (nonatomic, retain) RCTBridge *appBridge;
+
++ (id)sharedInstance;
+
+@end

--- a/RNTableView/RNAppGlobals.m
+++ b/RNTableView/RNAppGlobals.m
@@ -1,0 +1,24 @@
+//
+//  RNGlobals.m
+//  RNTableView
+//
+//  Created by Anna Berman on 2/10/16.
+//  Copyright © 2016 Pavlo Aksonov. All rights reserved.
+//
+
+#import "RNAppGlobals.h"
+
+@implementation RNAppGlobals
+
+@synthesize appBridge;
+
++ (id)sharedInstance {
+    static RNAppGlobals *instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[self alloc] init];
+    });
+    return instance;
+}
+
+@end

--- a/RNTableView/RNReactModuleCell.h
+++ b/RNTableView/RNReactModuleCell.h
@@ -1,0 +1,19 @@
+
+#import <UIKit/UIKit.h>
+
+//Use react-native root views as reusable cells returned from cellForRowAtIndexPath.
+
+//App must use the code below to store the app bridge, else cells will be blank
+//AppDelegate.m, didFinishLaunchingWithOptions:
+// #import <RNTableView/RNAppGlobals.h>
+//RCTRootView *rootView = ...
+//[[RNAppGlobals sharedInstance] setAppBridge:rootView.bridge];
+
+@interface RNReactModuleCell : UITableViewCell {
+}
+
+- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier bridge:(RCTBridge*) bridge data:(NSDictionary*)data indexPath:(NSIndexPath*)indexPath reactModule:(NSString*)reactModule;
+
+-(void)setUpAndConfigure:(NSDictionary*)data bridge:(RCTBridge*)bridge indexPath:(NSIndexPath*)indexPath reactModule:(NSString*)reactModule;
+
+@end

--- a/RNTableView/RNReactModuleCell.m
+++ b/RNTableView/RNReactModuleCell.m
@@ -1,0 +1,54 @@
+//
+//  RNReactModuleCell.m
+//  RNTableView
+//
+//  Created by Anna Berman on 2/6/16.
+//  Copyright © 2016 Pavlo Aksonov. All rights reserved.
+//
+
+#import <RCTRootView.h>
+#import "RNReactModuleCell.h"
+
+@implementation RNReactModuleCell {
+    RCTRootView *_rootView;
+}
+
+- (id)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier bridge:(RCTBridge*) bridge data:(NSDictionary*)data indexPath:(NSIndexPath*)indexPath reactModule:(NSString*)reactModule
+{
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        [self setUpAndConfigure:data bridge:bridge indexPath:indexPath reactModule:reactModule];
+    }
+    return self;
+}
+
+-(NSDictionary*) toProps:(NSDictionary *)data indexPath:(NSIndexPath*)indexPath {
+    return @{@"data":data, @"section":[[NSNumber alloc] initWithLong:indexPath.section], @"row":[[NSNumber alloc] initWithLong:indexPath.row]};
+}
+
+-(void)setUpAndConfigure:(NSDictionary*)data bridge:(RCTBridge*)bridge indexPath:(NSIndexPath*)indexPath reactModule:(NSString*)reactModule{
+    NSDictionary *props = [self toProps:data indexPath:indexPath];
+    if (_rootView == nil) {
+        //Create the mini react app that will populate our cell. This will be called from cellForRowAtIndexPath
+        _rootView = [[RCTRootView alloc] initWithBridge:bridge moduleName:reactModule initialProperties:props];
+        if (data[@"width"]) {
+            CGRect contentViewFrame = self.contentView.frame;
+            contentViewFrame.size.width = ((NSNumber*)data[@"width"]).floatValue;
+            self.contentView.frame = contentViewFrame;
+        }
+        [self.contentView addSubview:_rootView];
+        _rootView.frame = self.contentView.frame;
+    } else {
+        //Ask react to re-render us with new data
+        _rootView.appProperties = props;
+    }
+    
+    //The application will be unmounted in javascript when the cell/rootview is destroyed
+}
+
+-(void)prepareForReuse {
+    [super prepareForReuse];
+    //TODO prevent stale data flickering
+}
+
+@end

--- a/RNTableView/RNTableView.h
+++ b/RNTableView/RNTableView.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 @class RCTEventDispatcher;
+@class RCTBridge;
 
 @protocol RNTableViewDatasource <NSObject>
 
@@ -21,7 +22,7 @@
 
 @interface RNTableView : UIView
 
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher bridge:(RCTBridge*) bridge NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSMutableArray *sections;
 @property (nonatomic, copy) NSArray *additionalItems;
@@ -58,5 +59,6 @@
 @property (nonatomic) BOOL autoFocus;
 @property (nonatomic) BOOL allowsToggle;
 @property (nonatomic) BOOL allowsMultipleSelection;
+@property (nonatomic) NSString *reactModuleForCell;
 
 @end

--- a/RNTableView/RNTableView.h
+++ b/RNTableView/RNTableView.h
@@ -8,7 +8,6 @@
 
 #import <UIKit/UIKit.h>
 @class RCTEventDispatcher;
-@class RCTBridge;
 
 @protocol RNTableViewDatasource <NSObject>
 
@@ -22,7 +21,7 @@
 
 @interface RNTableView : UIView
 
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher bridge:(RCTBridge*) bridge NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSMutableArray *sections;
 @property (nonatomic, copy) NSArray *additionalItems;

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -70,12 +70,12 @@
     }
 }
 
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher bridge:(RCTBridge*)bridge
+- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
 {
     RCTAssertParam(eventDispatcher);
     
     if ((self = [super initWithFrame:CGRectZero])) {
-        _bridge = [[RNAppGlobals sharedInstance] appBridge] ?: bridge;
+        _bridge = [[RNAppGlobals sharedInstance] appBridge];
         _eventDispatcher = eventDispatcher;
         _cellHeight = 44;
         _cells = [NSMutableArray array];
@@ -286,7 +286,6 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
                 if(selectedIndex == -1)
                     selectedIndex = [items count];
                 itemData[@"selected"] = @YES;
-                
                 found = YES;
             }
             [items addObject:itemData];
@@ -322,6 +321,9 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 }
 
 -(UITableViewCell*)setupReactModuleCell:(UITableView *)tableView data:(NSDictionary*)data indexPath:(NSIndexPath *)indexPath {
+    RCTAssert(_bridge, @"Must set global bridge in AppDelegate, e.g. \n\
+              #import <RNTableView/RNAppGlobals.h>\n\
+              [[RNAppGlobals sharedInstance] setAppBridge:rootView.bridge]");
     RNReactModuleCell *cell = [tableView dequeueReusableCellWithIdentifier:_reactModuleCellReuseIndentifier];
     if (cell == nil) {
         cell = [[RNReactModuleCell alloc] initWithStyle:self.tableViewCellStyle reuseIdentifier:_reactModuleCellReuseIndentifier bridge: _bridge data:data indexPath:indexPath reactModule:_reactModuleForCell];

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -15,6 +15,8 @@
 #import "RNCellView.h"
 #import "RNTableFooterView.h"
 #import "RNTableHeaderView.h"
+#import "RNReactModuleCell.h"
+#import "RNAppGlobals.h"
 
 @interface RNTableView()<UITableViewDataSource, UITableViewDelegate> {
     id<RNTableViewDatasource> datasource;
@@ -25,9 +27,11 @@
 @end
 
 @implementation RNTableView {
+    RCTBridge *_bridge;
     RCTEventDispatcher *_eventDispatcher;
     NSArray *_items;
     NSMutableArray *_cells;
+    NSString *_reactModuleCellReuseIndentifier;
 }
 
 -(void)setEditing:(BOOL)editing {
@@ -66,11 +70,12 @@
     }
 }
 
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
+- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher bridge:(RCTBridge*)bridge
 {
     RCTAssertParam(eventDispatcher);
     
     if ((self = [super initWithFrame:CGRectZero])) {
+        _bridge = [[RNAppGlobals sharedInstance] appBridge] ?: bridge;
         _eventDispatcher = eventDispatcher;
         _cellHeight = 44;
         _cells = [NSMutableArray array];
@@ -148,6 +153,8 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     _tableView.tableHeaderView = view;
     _tableView.tableFooterView = view;
     _tableView.separatorStyle = self.separatorStyle;
+    _reactModuleCellReuseIndentifier = @"ReactModuleCell";
+    [_tableView registerClass:[RNReactModuleCell class] forCellReuseIdentifier:_reactModuleCellReuseIndentifier];
     [self addSubview:_tableView];
 }
 - (void)tableView:(UITableView *)tableView willDisplayFooterView:(nonnull UIView *)view forSection:(NSInteger)section {
@@ -279,6 +286,7 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
                 if(selectedIndex == -1)
                     selectedIndex = [items count];
                 itemData[@"selected"] = @YES;
+                
                 found = YES;
             }
             [items addObject:itemData];
@@ -312,20 +320,35 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     }
     return count;
 }
+
+-(UITableViewCell*)setupReactModuleCell:(UITableView *)tableView data:(NSDictionary*)data indexPath:(NSIndexPath *)indexPath {
+    RNReactModuleCell *cell = [tableView dequeueReusableCellWithIdentifier:_reactModuleCellReuseIndentifier];
+    if (cell == nil) {
+        cell = [[RNReactModuleCell alloc] initWithStyle:self.tableViewCellStyle reuseIdentifier:_reactModuleCellReuseIndentifier bridge: _bridge data:data indexPath:indexPath reactModule:_reactModuleForCell];
+    } else {
+        [cell setUpAndConfigure:data bridge:_bridge indexPath:indexPath reactModule:_reactModuleForCell];
+    }
+    return cell;
+}
+
 -(UITableViewCell* )tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:@"Cell"];
+    UITableViewCell *cell = nil;
     NSDictionary *item = [self dataForRow:indexPath.item section:indexPath.section];
     
     // check if it is standard cell or user-defined UI
-    if (![self hasCustomCells:indexPath.section]){
+    if ([self hasCustomCells:indexPath.section]){
+        cell = ((RNCellView *)_cells[indexPath.section][indexPath.row]).tableViewCell;
+    } else if (self.reactModuleForCell != nil && ![self.reactModuleForCell isEqualToString:@""]) {
+        cell = [self setupReactModuleCell:tableView data:item indexPath:indexPath];
+    } else {
+        cell = [tableView dequeueReusableCellWithIdentifier:@"Cell"];
         if (cell == nil) {
             cell = [[UITableViewCell alloc] initWithStyle:self.tableViewCellStyle reuseIdentifier:@"Cell"];
         }
         cell.textLabel.text = item[@"label"];
         cell.detailTextLabel.text = item[@"detail"];
-    } else {
-        cell = ((RNCellView *)_cells[indexPath.section][indexPath.row]).tableViewCell;
     }
+    
     if (item[@"selected"] && [item[@"selected"] intValue]){
         cell.accessoryType = UITableViewCellAccessoryCheckmark;
     } else if ([item[@"arrow"] intValue]) {
@@ -354,7 +377,8 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 
 -(CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
     if (![self hasCustomCells:indexPath.section]){
-        return _cellHeight;
+        NSNumber *styleHeight = _sections[indexPath.section][@"items"][indexPath.row][@"height"];
+        return styleHeight.floatValue ?: _cellHeight;
     } else {
         RNCellView *cell = (RNCellView *)_cells[indexPath.section][indexPath.row];
         CGFloat height =  cell.componentHeight;

--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -16,7 +16,7 @@
 RCT_EXPORT_MODULE()
 - (UIView *)view
 {
-    return [[RNTableView alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
+    return [[RNTableView alloc] initWithEventDispatcher:self.bridge.eventDispatcher bridge:self.bridge];
 }
 
 RCT_EXPORT_VIEW_PROPERTY(sections, NSArray)
@@ -54,6 +54,11 @@ RCT_CUSTOM_VIEW_PROPERTY(tableViewCellStyle, UITableViewStyle, RNTableView) {
 
 RCT_CUSTOM_VIEW_PROPERTY(tableViewCellEditingStyle, UITableViewCellEditingStyle, RNTableView) {
     [view setTableViewCellEditingStyle:[RCTConvert NSInteger:json]];
+}
+
+/*Each cell is a separate app, multiple cells share the app/module name*/
+RCT_CUSTOM_VIEW_PROPERTY(reactModuleForCell, NSString*, RNTableView) {
+    [view setReactModuleForCell:[RCTConvert NSString:json]];
 }
 
 RCT_CUSTOM_VIEW_PROPERTY(contentInset, UIEdgeInsets, RNTableView) {

--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -16,7 +16,7 @@
 RCT_EXPORT_MODULE()
 - (UIView *)view
 {
-    return [[RNTableView alloc] initWithEventDispatcher:self.bridge.eventDispatcher bridge:self.bridge];
+    return [[RNTableView alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
 }
 
 RCT_EXPORT_VIEW_PROPERTY(sections, NSArray)

--- a/examples/TableViewDemo/iOS/AppDelegate.m
+++ b/examples/TableViewDemo/iOS/AppDelegate.m
@@ -10,6 +10,7 @@
 #import "AppDelegate.h"
 
 #import "RCTRootView.h"
+#import <RNTableView/RNAppGlobals.h>
 
 @implementation AppDelegate
 
@@ -43,10 +44,15 @@
    * see http://facebook.github.io/react-native/docs/runningondevice.html
    */
 
-//   jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
+  
+//  jsCodeLocation = [[NSBundle mainBundle] URLForResource:@"main" withExtension:@"jsbundle"];
 
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"TableViewExample" initialProperties:@{} launchOptions:launchOptions];
+  
+  //Save main bridge so that RNTableView could access our bridge to create its RNReactModuleCells
+  [[RNAppGlobals sharedInstance] setAppBridge:rootView.bridge];
+  
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [[UIViewController alloc] init];

--- a/examples/TableViewDemo/index.ios.js
+++ b/examples/TableViewDemo/index.ios.js
@@ -186,7 +186,6 @@ class FirebaseExample extends React.Component {
         this.propPrefix = "dinosaur";
     }
     componentDidMount() {
-        var dinData = null;
         var self = this;
         this.ref = new Firebase(this.firebaseLocation);
         this.ref.on('value', function(snapshot) {
@@ -260,7 +259,7 @@ class CustomEditableExample extends React.Component {
                 setTimeout(()=> self.onExternalData(newData), 2);
             });
         } else {
-            this.preEditData = Object.assign({}, this.state.data);
+            this.preEditData = this.state.data.slice(0);
             //Must be same ordering as used in rendering items
             this.dataItemKeysBeingEdited = Object.keys(this.state.data || {});
             this.setState({editing: true});

--- a/examples/TableViewDemo/index.ios.js
+++ b/examples/TableViewDemo/index.ios.js
@@ -1,20 +1,21 @@
 'use strict';
 
 var React = require('react-native');
-var { AppRegistry, Text, Dimensions,View } = React;
+var { AppRegistry, Text, Dimensions, View, TouchableHighlight, TextInput } = React;
 var TableView = require('react-native-tableview');
 var Section = TableView.Section;
 var Item = TableView.Item;
 var Cell = TableView.Cell;
 var {Actions, Router, Route, Schema, Animations} = require('react-native-router-flux');
 var NavigationBar = require('react-native-navbar');
+var Firebase = require('firebase');
 
 class NavBar extends React.Component {
     render(){
         return <NavigationBar style={{backgroundColor: '#0db0d9'}}
                               titleColor='white'
                               buttonsColor='white'
-                              statusBar='lightContent' {...this.props} />
+                              {...this.props} />
     }
 }
 class Example1 extends React.Component {
@@ -112,6 +113,286 @@ class Example3 extends React.Component {
     }
 }
 
+//Similar to example 2 but use "TableViewExampleCell" reusable cells
+class ReusableCellExample1 extends React.Component {
+    // list spanish provinces and add 'All states' item at the beginning
+    render() {
+        var country = "ES";
+        return (
+            <TableView selectedValue="" reactModuleForCell="TableViewExampleCell" style={{flex:1}} json="states" filter={`country=='${country}'`}
+                       tableViewCellStyle={TableView.Consts.CellStyle.Subtitle}
+                       onPress={(event) => alert(JSON.stringify(event))}>
+                <Item value="">All states</Item>
+            </TableView>
+        );
+    }
+}
+
+class ReusableCellExample2 extends React.Component {
+    render(){
+        var numAdditionaItems = 1000;
+        var moreItems = [];
+        for (var i = 0; i < numAdditionaItems; ++i) {
+            moreItems.push(i);
+        }
+        return (
+            <TableView reactModuleForCell="TableViewExampleCell" style={{flex:1}}
+                       allowsToggle={true}
+                       allowsMultipleSelection={true}
+                       tableViewStyle={TableView.Consts.Style.Grouped}
+                       onPress={(event) => alert(JSON.stringify(event))}>
+                <Section label="Section 1" arrow={true}>
+                    <Item>Item 1</Item>
+                    <Item>Item 2</Item>
+                    <Item>Item 3</Item>
+                    <Item backgroundColor="gray" height={44}>Item 4</Item>
+                    <Item>Item 5</Item>
+                    <Item>Item 6</Item>
+                    <Item>Item 7</Item>
+                    <Item>Item 8</Item>
+                    <Item>Item 9</Item>
+                    <Item backgroundColor="red" height={200}>Item 10</Item>
+                    <Item>Item 11</Item>
+                    <Item>Item 12</Item>
+                    <Item>Item 13</Item>
+                    <Item>Item 14</Item>
+                    <Item>Item 15</Item>
+                    <Item>Item 16</Item>
+                </Section>
+                <Section label="Section 2" arrow={false}>
+                    <Item>Item 1</Item>
+                    <Item>Item 2</Item>
+                    <Item>Item 3</Item>
+                </Section>
+                <Section label="Section 3" arrow={true}>
+                    <Item>Item 1</Item>
+                    <Item>Item 2</Item>
+                    <Item>Item 3</Item>
+                </Section>
+                <Section label={"large section - "+numAdditionaItems+" items"}>
+                    {moreItems.map((i)=><Item key={i+1}>{i+1}</Item>)}
+                </Section>
+            </TableView>
+        );
+    }
+}
+
+class FirebaseExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {data:null};
+        this.reactCellModule = "DinosaurCellExample";
+        this.firebaseLocation = "https://dinosaur-facts.firebaseio.com/dinosaurs";
+        this.propPrefix = "dinosaur";
+    }
+    componentDidMount() {
+        var dinData = null;
+        var self = this;
+        this.ref = new Firebase(this.firebaseLocation);
+        this.ref.on('value', function(snapshot) {
+            self.setState({data:snapshot.val()});
+        });
+    }
+    componentWillUnmount() {
+        this.ref.off();
+    }
+    renderItem(itemData, key, index) {
+        //TODO passing itemData={itemData} doesn't seem to work... so pass all data props with a prefix to make sure they don't clash
+        //with other <Item> props
+        var item = {};
+        Object.keys(itemData||{}).forEach(k => {
+           item[this.propPrefix+k] = itemData[k];
+        });
+        item[this.propPrefix+"key"] = key;
+
+        return (<Item {...item} height={140} backgroundColor={index%2==0?"white":"grey"} key={key} label={key}></Item>);
+    }
+    render() {
+        var data = this.state.data;
+        if (!data) {
+            return <Text style={{height:580}}>NO DATA</Text>
+        }
+
+        var self = this;
+        var items = Object.keys(data).map((key,index)=>self.renderItem(data[key], key, index));
+
+        return (
+            <View style={{flex:1}}>
+                <Text value="">All Items</Text>
+                <TableView style={{flex:1}} reactModuleForCell={this.reactCellModule}
+                           tableViewCellStyle={TableView.Consts.CellStyle.Default}
+                           onPress={(event) => alert(JSON.stringify(event))}>
+                    <Section arrow={true}>
+                        {items}
+                    </Section>
+                </TableView>
+            </View>
+        );
+    }
+}
+
+
+class CustomEditableExample extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {data:null,editing:false,text:""};
+        this.reactCellModule = "TableViewExampleCell2";
+    }
+    onExternalData(data) {
+        var self = this;
+        if (self.state.editing) {
+            console.warn("Ignoring update from firebase while editing data locally");
+        } else {
+            self.setState({data:data});
+        }
+    }
+    editOrSave() {
+        if (this.state.editing) {
+            //Save edited data
+            
+            var self = this;
+            var newData = (this.dataItemKeysBeingEdited || []).map(itemKey=>self.preEditData[itemKey]);
+            this.dataItemKeysBeingEdited = null;
+            this.preEditData = null;
+
+            this.setState({editing: false, data: newData}, function() {
+                //Simulate saving data remotely and getting a data-changed callback
+                setTimeout(()=> self.onExternalData(newData), 2);
+            });
+        } else {
+            this.preEditData = Object.assign({}, this.state.data);
+            //Must be same ordering as used in rendering items
+            this.dataItemKeysBeingEdited = Object.keys(this.state.data || {});
+            this.setState({editing: true});
+        }
+    }
+    cancelEditing() {
+        var data = this.preEditData;
+        this.dataItemKeysBeingEdited = null;
+        this.preEditData = null;
+        var self = this;
+
+        self.setState({editing: false, data: data});
+    }
+    moveItem(info) {
+        if (!this.dataItemKeysBeingEdited || info.sourceIndex >= this.dataItemKeysBeingEdited.length
+            || info.destinationIndex >= this.dataItemKeysBeingEdited.length) {
+            console.error("moved row source/destination indices are out of range");
+            return;
+        }
+        var itemKey = this.dataItemKeysBeingEdited[info.sourceIndex];
+        this.dataItemKeysBeingEdited.splice(info.sourceIndex, 1);
+        this.dataItemKeysBeingEdited.splice(info.destinationIndex, 0, itemKey);
+
+        var self = this;
+        var newData = (this.dataItemKeysBeingEdited || []).map(itemKey=>self.preEditData[itemKey]);
+        this.setState({data: newData});
+    }
+    deleteItem(info) {
+        if (!this.dataItemKeysBeingEdited || info.selectedIndex >= this.dataItemKeysBeingEdited.length) {
+            console.error("deleted row index is out of range");
+            return;
+        }
+        this.dataItemKeysBeingEdited.splice(info.selectedIndex, 1);
+
+        var self = this;
+        var newData = (this.dataItemKeysBeingEdited || []).map(itemKey=>self.preEditData[itemKey]);
+        this.setState({data: newData});
+    }
+    addItem() {
+        var {text} = this.state;
+        if (!text) return;
+        var self = this;
+
+        //Simulate saving data remotely and getting a data-changed callback
+        setTimeout(()=>self.onExternalData(!this.state.data?[text]:[...(this.state.data), text]), 2);
+
+        //clear text & hide keyboard
+        this.setState({text:""});
+        this.refs.addTextInput.blur();
+    }
+    onChange(info) {
+        if (info.mode == 'move') {
+            this.moveItem(info);
+        } else if (info.mode == 'delete') {
+            this.deleteItem(info);
+        } else {
+            console.error("unknown change mode: "+info.mode);
+        }
+    }
+    renderItem(itemData, key, index) {
+        return (
+            <Item key={key} label={itemData}>
+            </Item>);
+    }
+    getNavProps() {
+        var self = this;
+        var navProps = {
+            title:{title:"Custom Editable"},
+            rightButton: {
+                title: (this.state.editing? 'Save':'Edit'),
+                handler: function onNext() {
+                    self.editOrSave();
+                }
+            }
+        };
+        navProps.leftButton = {
+            title: (this.state.editing?'Cancel':'Back'),
+            handler: function onNext() {
+                if (self.state.editing)
+                    self.cancelEditing();
+                else {
+                    Actions.pop();
+                }
+            }
+        };
+        return navProps;
+    }
+    getAddItemRow() {
+        return (
+            <View style={{paddingBottom: 4, height:44, flexDirection:"row", alignItems:"stretch"}}>
+                <TextInput ref="addTextInput"
+                           style={{flex:1, height: 40, borderColor: 'gray', borderWidth: 1}}
+                           onChangeText={(text) => this.setState({text:text})}
+                           value={this.state.text}
+                    />
+
+                <TouchableHighlight onPress={(event)=>{this.addItem()}}
+                                    style={{borderRadius:5, width:100,backgroundColor:"red",alignItems:"center",justifyContent:"center"}}>
+                    <Text>Add</Text>
+                </TouchableHighlight>
+            </View>
+        );
+    }
+    render() {
+        var {data, editing} = this.state;
+        if (!data) {
+            data = {};
+        }
+
+        var self = this;
+        var items = Object.keys(data).map((key,index)=>self.renderItem(data[key], key, index));
+
+        return (
+            <View style={{flex:1, marginTop:0}}>
+
+                <NavBar {...this.getNavProps()}/>
+
+                {!editing && this.getAddItemRow()}
+
+                <TableView editing={editing} style={{flex:1}} reactModuleForCell={this.reactCellModule}
+                           tableViewCellStyle={TableView.Consts.CellStyle.Default}
+                           onChange={this.onChange.bind(this)}
+                    >
+                    <Section canMove={editing} canEdit={editing} arrow={!editing}>
+                        {items}
+                    </Section>
+                </TableView>
+            </View>
+        );
+    }
+}
+
 class Edit extends React.Component {
     constructor(props){
         super(props);
@@ -124,22 +405,66 @@ class Edit extends React.Component {
                 <NavBar {...this.props} nextTitle={this.state.editing ? "Done" : "Edit"}
                                         onNext={()=>self.setState({editing: !self.state.editing})}/>
                 <TableView style={{flex:1}} editing={this.state.editing}
-                       onPress={(event) => alert(JSON.stringify(event))} onChange={(event) => alert("CHANGED:"+JSON.stringify(event))}>
-                <Section canMove={true} canEdit={true}>
-                    <Item canEdit={false}>Item 1</Item>
-                    <Item>Item 2</Item>
-                    <Item>Item 3</Item>
-                    <Item>Item 4</Item>
-                    <Item>Item 5</Item>
-                    <Item>Item 6</Item>
-                    <Item>Item 7</Item>
-                    <Item>Item 8</Item>
-                </Section>
-            </TableView>
-                </View>
+                           onPress={(event) => alert(JSON.stringify(event))} onChange={(event) => alert("CHANGED:"+JSON.stringify(event))}>
+                    <Section canMove={true} canEdit={true}>
+                        <Item canEdit={false}>Item 1</Item>
+                        <Item>Item 2</Item>
+                        <Item>Item 3</Item>
+                        <Item>Item 4</Item>
+                        <Item>Item 5</Item>
+                        <Item>Item 6</Item>
+                        <Item>Item 7</Item>
+                        <Item>Item 8</Item>
+                    </Section>
+                </TableView>
+            </View>
         );
     }
 }
+class ListViewExample extends React.Component {
+    constructor(props){
+        super(props);
+        this.numAdditionaItems = 1000;
+        this.data = {};
+        for (var i = 0; i < this.numAdditionaItems; ++i) {
+            this.data[i] = i;
+        }
+        this.state = {dataSource: new React.ListView.DataSource({
+            rowHasChanged: (r1, r2) => r1 !== r2
+        })};
+    }
+    render() {
+        const data = this.data;
+        return (
+            <React.ListView
+                dataSource={this.state.dataSource.cloneWithRows(Object.keys(data))}
+                renderRow={(k) => <Text onPress={(e)=>alert("item:"+k+", "+data[k])}> data: {data[k]}</Text>}
+                />
+        );
+    }
+}
+
+class LargeTableExample extends React.Component {
+    render() {
+        var numAdditionaItems = 1000;
+        var items = [];
+        for (var i = 0; i < numAdditionaItems; ++i) {
+            items.push(i);
+        }
+        return (
+            <TableView reactModuleForCell="TableViewExampleCell" style={{flex:1}}
+                           allowsToggle={true}
+                           allowsMultipleSelection={true}
+                           tableViewStyle={TableView.Consts.Style.Grouped}
+                           onPress={(event) => alert(JSON.stringify(event))}>
+                <Section label={"large section - "+numAdditionaItems+" items"} arrow={true}>
+                    {items.map((i)=><Item key={i+1}>{i+1}</Item>)}
+                </Section>
+            </TableView>
+        );
+    }
+}
+
 
 class Launch extends React.Component {
     constructor(props) {
@@ -158,6 +483,12 @@ class Launch extends React.Component {
                     <Item onPress={Actions.example2}>Example with app bundle JSON data</Item>
                     <Item onPress={Actions.example3}>Example with multiple sections</Item>
                     <Item onPress={Actions.edit}>Example with editing mode</Item>
+                    <Item onPress={Actions.example4}>Reusable Cell Example 1</Item>
+                    <Item onPress={Actions.example5}>Reusable Custom Cells</Item>
+                    <Item onPress={Actions.example6}>Firebase Example</Item>
+                    <Item onPress={Actions.example7}>Large ListView (scroll memory growth)</Item>
+                    <Item onPress={Actions.example8}>Reusable Large TableView Example</Item>
+                    <Item onPress={Actions.example9}>Custom Editing Example</Item>
                 </Section>
             </TableView>
         );
@@ -173,11 +504,90 @@ class TableViewExample extends React.Component {
                 <Route name="example1" component={Example1} title="Example 1"/>
                 <Route name="example2" component={Example2} title="Example 2"/>
                 <Route name="example3" component={Example3} title="Example 3"/>
-                <Route name="edit" component={Edit} title="Edit Table" hideNavBar={true}/>
+                <Route name="edit" component={Edit} hideNavBar={true}/>
+                <Route name="example4" component={ReusableCellExample1} title="Reusable Cell Example 1"/>
+                <Route name="example5" component={ReusableCellExample2} title="Reusable Custom Cells"/>
+                <Route name="example6" component={FirebaseExample} title="Firebase Example"/>
+                <Route name="example7" component={ListViewExample} title="Large ListView Example"/>
+                <Route name="example8" component={LargeTableExample} title="Reusable Large TableView Example"/>
+                <Route name="example9" component={CustomEditableExample} hideNavBar={true} title="Custom Editing Example"/>
             </Router>
 
         );
     }
 }
 
+//Should be pure... setState on top-level component doesn't seem to work
+class TableViewExampleCell extends React.Component {
+    render(){
+        var style = {borderColor:"#aaaaaa", borderWidth:1, borderRadius:3};
+        //cell height is passed from <Item> child of tableview and native code passes it back up to javascript in "app params" for the cell.
+        //This way our component will fill the full native table cell height.
+        if (this.props.data.height !== undefined) {
+            style.height = this.props.data.height;
+        } else {
+            style.flex = 1;
+        }
+        if (this.props.data.backgroundColor !== undefined) {
+            style.backgroundColor = this.props.data.backgroundColor;
+        }
+        return (<View style={style}><Text>section:{this.props.section},row:{this.props.row},label:{this.props.data.label}</Text></View>);
+    }
+}
+
+//Should be pure... setState on top-level component doesn't seem to work
+class TableViewExampleCell2 extends React.Component {
+    render(){
+        var style = {};
+        //cell height is passed from <Item> child of tableview and native code passes it back up to javascript in "app params" for the cell.
+        //This way our component will fill the full native table cell height.
+        if (this.props.data.height !== undefined) {
+            style.height = this.props.data.height;
+        } else {
+            style.flex = 1;
+        }
+        if (this.props.data.backgroundColor !== undefined) {
+            style.backgroundColor = this.props.data.backgroundColor;
+        }
+        return (<View style={style}><Text>{this.props.data.label}</Text></View>);
+    }
+}
+
+//Should be pure... setState on top-level component doesn't seem to work
+class DinosaurCellExample extends React.Component {
+    yearsAgoInMil(num) {
+        return ((-1 * num)/1000000)+" million years ago";
+    }
+    render(){
+        var style = {};
+        //cell height is passed from <Item> child of tableview and native code passes it back up to javascript in "app params" for the cell.
+        //This way our component will fill the full native table cell height.
+        if (this.props.data.height !== undefined) {
+            style.height = this.props.data.height;
+        }
+        if (this.props.data.backgroundColor !== undefined) {
+            style.backgroundColor = this.props.data.backgroundColor;
+        }
+        style.borderColor = "grey";
+        style.borderRadius = 0.02;
+
+        var appeared = this.yearsAgoInMil(this.props.data.dinosaurappeared);
+        var vanished = this.yearsAgoInMil(this.props.data.dinosaurvanished);
+        return (<View style={style}>
+            <Text style={{backgroundColor:"#4fa2c3"}}>Name: {this.props.data.dinosaurkey}</Text>
+            <Text>Order:{this.props.data.dinosaurorder}</Text>
+            <Text>Appeared: {appeared}</Text>
+            <Text style={{backgroundColor:"lightgrey"}}>Vanished: {vanished}</Text>
+            <Text>Height: {this.props.data.dinosaurheight}</Text>
+            <Text>Length: {this.props.data.dinosaurlength}</Text>
+            <Text>Weight: {this.props.data.dinosaurweight}</Text>
+        </View>);
+    }
+}
+
+
+
 AppRegistry.registerComponent('TableViewExample', () => TableViewExample);
+AppRegistry.registerComponent('TableViewExampleCell', () => TableViewExampleCell);
+AppRegistry.registerComponent('TableViewExampleCell2', () => TableViewExampleCell2);
+AppRegistry.registerComponent('DinosaurCellExample', () => DinosaurCellExample);

--- a/examples/TableViewDemo/index.ios.js
+++ b/examples/TableViewDemo/index.ios.js
@@ -259,7 +259,7 @@ class CustomEditableExample extends React.Component {
                 setTimeout(()=> self.onExternalData(newData), 2);
             });
         } else {
-            this.preEditData = this.state.data.slice(0);
+            this.preEditData = (this.state.data || []).slice(0);
             //Must be same ordering as used in rendering items
             this.dataItemKeysBeingEdited = Object.keys(this.state.data || {});
             this.setState({editing: true});

--- a/examples/TableViewDemo/package.json
+++ b/examples/TableViewDemo/package.json
@@ -6,9 +6,11 @@
     "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react-native": "^0.14.2",
-    "react-native-navbar": "^0.8.2",
-    "react-native-router-flux": "^0.3.0",
-    "react-native-tableview": "1.4.1"
+    "firebase": "^2.4.0",
+    "react-native": "^0.19.0",
+    "react-native-navbar": "^1.2.0",
+    "react-native-router-flux": "^2.1.8",
+    "react-native-tableview": "1.4.2",
+    "react-native-tabs": "^0.1.10"
   }
 }

--- a/index.js
+++ b/index.js
@@ -50,6 +50,13 @@ var TableView = React.createClass({
          * @platform ios
          */
         scrollIndicatorInsets: React.EdgeInsetsPropType,
+        tableViewCellEditingStyle: React.PropTypes.number,
+    },
+
+    getDefaultProps() {
+        return {
+            tableViewCellEditingStyle: RNTableViewConsts.CellEditingStyle.Delete,
+        };
     },
 
     getInitialState: function() {
@@ -125,7 +132,7 @@ var TableView = React.createClass({
                     additionalItems={this.state.additionalItems}
                     tableViewStyle={TableView.Consts.Style.Plain}
                     tableViewCellStyle={TableView.Consts.CellStyle.Subtitle}
-                    tableViewCellEditingStyle={TableView.Consts.CellEditingStyle.Delete}
+                    tableViewCellEditingStyle={this.props.tableViewCellEditingStyle}
                     separatorStyle={TableView.Consts.SeparatorStyle.Line}
                     scrollIndicatorInsets={this.props.contentInset}
                     {...this.props}


### PR DESCRIPTION
backwards compatible, but intended to replace `<Cell>` custom cells; examples are in TableViewDemo (LargeTableExample and  FirebaseExample).
Fixes issues with loading large data sets (#22) and re-rendering custom cells on data changes (#19).

Usage: instead of `Cell`'s, use reactModuleForCell prop:

```
class LargeTableExample extends React.Component {
    render() {
        var numItems = 1000;
        var items = [];
        for (var i = 0; i < numItems; ++i) {
            items.push(i);
        }
        //Item can have any string/number fields that will be passed to your reactModuleForCell component.
        //However some fields are already used internally by the native table/cells: 
        //   height, selected, transparent, width, canEdit, canMove.
        return (
            <TableView reactModuleForCell="TableViewExampleCell" style={{flex:1}}>
                <Section label={numItems+" items"} arrow={true}>
                    {items.map((i)=><Item key={i+1} custField1={"item "+i} height={50}/>)}
                </Section>
            </TableView>
        );
    }
}
class TableViewExampleCell extends React.Component {
    render(){
        var style = {};
        if (this.props.data.height !== undefined) {
            style.height = this.props.data.height;
        } else {
            style.flex = 1;
        }
        if (this.props.data.backgroundColor !== undefined) {
            style.backgroundColor = this.props.data.backgroundColor;
        }
        return (<View style={style}><Text>{this.props.data.custField1}</Text></View>);
    }
}

//Need to register the cell component so it can be rendered as a root view - this is the key 
//to letting ios control the lifetime of the cells while react just renders into them on demand.
AppRegistry.registerComponent('TableViewExampleCell', () => TableViewExampleCell);
```
