### PR TITLE
RNAppGlobals lines no longer need to be added to AppDelegate to use reactModuleForCell

### DIFF
--- a/RNTableView/RNAppGlobals.m
+++ b/RNTableView/RNAppGlobals.m
@@ -13,6 +13,8 @@
 @synthesize appBridge;
 
 + (id)sharedInstance {
+    NSLog(@"RNAppGlobals is deprecated/no longer needed and will be removed soon");
+    
     static RNAppGlobals *instance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/RNTableView/RNTableView.h
+++ b/RNTableView/RNTableView.h
@@ -7,7 +7,7 @@
 //
 
 #import <UIKit/UIKit.h>
-@class RCTEventDispatcher;
+@class RCTBridge;
 
 @protocol RNTableViewDatasource <NSObject>
 
@@ -21,7 +21,7 @@
 
 @interface RNTableView : UIView
 
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, copy) NSMutableArray *sections;
 @property (nonatomic, copy) NSArray *additionalItems;

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -16,7 +16,6 @@
 #import "RNTableFooterView.h"
 #import "RNTableHeaderView.h"
 #import "RNReactModuleCell.h"
-#import "RNAppGlobals.h"
 
 @interface RNTableView()<UITableViewDataSource, UITableViewDelegate> {
     id<RNTableViewDatasource> datasource;
@@ -70,13 +69,19 @@
     }
 }
 
-- (instancetype)initWithEventDispatcher:(RCTEventDispatcher *)eventDispatcher
-{
-    RCTAssertParam(eventDispatcher);
+- (instancetype)initWithBridge:(RCTBridge *)bridge {
+    RCTAssertParam(bridge);
+    RCTAssertParam(bridge.eventDispatcher);
 
     if ((self = [super initWithFrame:CGRectZero])) {
-        _bridge = [[RNAppGlobals sharedInstance] appBridge];
-        _eventDispatcher = eventDispatcher;
+        _eventDispatcher = bridge.eventDispatcher;
+        
+        _bridge = bridge;
+        while ([_bridge respondsToSelector:NSSelectorFromString(@"parentBridge")]
+               && [_bridge valueForKey:@"parentBridge"]) {
+            _bridge = [_bridge valueForKey:@"parentBridge"];
+        }
+
         _cellHeight = 44;
         _cells = [NSMutableArray array];
         _autoFocus = YES;

--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -16,7 +16,7 @@
 RCT_EXPORT_MODULE()
 - (UIView *)view
 {
-    return [[RNTableView alloc] initWithEventDispatcher:self.bridge.eventDispatcher];
+    return [[RNTableView alloc] initWithBridge:self.bridge];
 }
 
 - (NSArray *)customDirectEventTypes

--- a/examples/TableViewDemo/iOS/AppDelegate.m
+++ b/examples/TableViewDemo/iOS/AppDelegate.m
@@ -52,7 +52,6 @@
   
   //Save main bridge so that RNTableView could access our bridge to create its RNReactModuleCells
   [[RNAppGlobals sharedInstance] setAppBridge:rootView.bridge];
-  
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [[UIViewController alloc] init];


### PR DESCRIPTION
existing apps that use RNAppGlobals will continue to work but eventually RNAppGlobals can be removed