### PR TITLE
Section Index Title Scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Native iOS UITableView for React Native with JSON support.
 - Use built-in accessory types (checkmark or disclosure indicator)
 - Automatic scroll to initial selected value during component initialization (autoFocus property)
 - Automatic item selection with "checkmark" with old item de-selection (optionally), see demo, useful to select country/state/etc.
+- Render Native Section Index Titles (sectionIndexTitlesEnabled property)
 - Native JSON support for datasource. If you need to display large dataset, generated Javascript will became very large and impact js loading time. To solve this problem the component could read JSON directly from app bundle without JS!
 - Filter JSON datasources using NSPredicate syntax. For example you could select states for given country only (check demo)
 - Create custom UITableView cells with flexible height using React Native syntax (TableView.Cell tag)

--- a/RNTableView/RNAppGlobals.h
+++ b/RNTableView/RNAppGlobals.h
@@ -1,5 +1,5 @@
 
-#import <foundation/Foundation.h>
+#import <Foundation/Foundation.h>
 @class RCTBridge;
 
 @interface RNAppGlobals : NSObject {

--- a/RNTableView/RNTableView.h
+++ b/RNTableView/RNTableView.h
@@ -69,6 +69,7 @@
 @property (nonatomic) NSString *reactModuleForCell;
 
 @property (nonatomic, assign) BOOL scrollEnabled;
+@property (nonatomic, assign) BOOL sectionIndexTitlesEnabled;
 
 - (void) scrollToOffsetX:(CGFloat)x offsetY:(CGFloat)y animated:(BOOL)animated;
 

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -484,7 +484,6 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     [tableView deselectRowAtIndexPath:indexPath animated:NO];
 
     NSInteger selectedIndex = [self.selectedIndexes[indexPath.section] integerValue];
-    NSMutableDictionary *oldValue = selectedIndex>=0 ?[self dataForRow:selectedIndex section:indexPath.section] : [NSMutableDictionary dictionaryWithDictionary:@{}];
 
     NSMutableDictionary *newValue = [self dataForRow:indexPath.item section:indexPath.section];
     newValue[@"target"] = self.reactTag;

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -160,6 +160,17 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     }
 }
 
+- (NSArray *)sectionIndexTitlesForTableView:(UITableView *)tableView {
+    // create selected indexes
+    NSMutableArray *keys = [NSMutableArray arrayWithCapacity:[_sections count]];
+
+    for (NSDictionary *section in _sections){
+        [keys addObject:section[@"label"]];
+    }
+
+    return keys;
+}
+
 #pragma mark - Public APIs
 
 - (void) scrollToOffsetX:(CGFloat)x offsetY:(CGFloat)y animated:(BOOL)animated {

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -31,6 +31,7 @@
     NSArray *_items;
     NSMutableArray *_cells;
     NSString *_reactModuleCellReuseIndentifier;
+    NSMutableDictionary *_lastValue;
 }
 
 -(void)setEditing:(BOOL)editing {
@@ -49,6 +50,11 @@
     _scrollEnabled = scrollEnabled;
 
     [self.tableView setScrollEnabled:scrollEnabled];
+}
+
+-(void)setSectionIndexTitlesEnabled:(BOOL)sectionIndexTitlesEnabled
+{
+    _sectionIndexTitlesEnabled = sectionIndexTitlesEnabled;
 }
 
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
@@ -155,6 +161,9 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     if (_autoFocus && selectedSection>=0 && [self numberOfSectionsInTableView:self.tableView] && [self tableView:self.tableView numberOfRowsInSection:selectedSection]){
         dispatch_async(dispatch_get_main_queue(), ^{
             NSIndexPath *indexPath = [NSIndexPath indexPathForItem:[_selectedIndexes[selectedSection] intValue ]inSection:selectedSection];
+            if (!_allowsMultipleSelection) {
+                _lastValue = [self dataForRow:indexPath.item section:indexPath.section];
+            }
             [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionMiddle animated:_autoFocusAnimate];
         });
     }
@@ -487,13 +496,14 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
      * otherwise, add selection to the new row and remove selection from old row if multiple is not allowed.
      * default: allowMultipleSelection:false and allowToggle: false
      */
-    if ((oldValue[@"selected"] && [oldValue[@"selected"] intValue]) || self.selectedValue){
+    if (self.selectedValue){
         if (_allowsToggle && newValue[@"selected"] && [newValue[@"selected"] intValue]) {
             [newValue removeObjectForKey:@"selected"];
         } else {
             if (!_allowsMultipleSelection) {
-                [oldValue removeObjectForKey:@"selected"];
+                [_lastValue removeObjectForKey:@"selected"];
             }
+
             [newValue setObject:@1 forKey:@"selected"];
         }
         [self.tableView reloadData];
@@ -501,6 +511,7 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 
     [_eventDispatcher sendInputEventWithName:@"press" body:newValue];
     self.selectedIndexes[indexPath.section] = [NSNumber numberWithInteger:indexPath.item];
+        _lastValue = newValue;
 }
 
 - (void)tableView:(UITableView *)tableView accessoryButtonTappedForRowWithIndexPath:(NSIndexPath *)indexPath {

--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -66,6 +66,10 @@ RCT_CUSTOM_VIEW_PROPERTY(scrollEnabled, BOOL, RNTableView) {
     [view setScrollEnabled:[RCTConvert BOOL:json]];
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(sectionIndexTitlesEnabled, BOOL, RNTableView) {
+    [view setSectionIndexTitlesEnabled:[RCTConvert BOOL:json]];
+}
+
 RCT_EXPORT_VIEW_PROPERTY(cellForRowAtIndexPath, NSArray)
 
 RCT_CUSTOM_VIEW_PROPERTY(tableViewCellStyle, UITableViewStyle, RNTableView) {

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ var TableView = React.createClass({
         footerTextColor: React.PropTypes.string,
         separatorColor: React.PropTypes.string,
         scrollEnabled: React.PropTypes.bool,
+        sectionIndexTitlesEnabled: React.PropTypes.bool,
         showsHorizontalScrollIndicator: React.PropTypes.bool,
         showsVerticalScrollIndicator: React.PropTypes.bool,
         onScroll: React.PropTypes.func,
@@ -74,6 +75,7 @@ var TableView = React.createClass({
             autoFocusAnimate: true,
             alwaysBounceVertical: true,
             scrollEnabled: true,
+            sectionIndexTitlesEnabled: false,
             showsHorizontalScrollIndicator: true,
             showsVerticalScrollIndicator: true,
         };


### PR DESCRIPTION
Fixes #125
- Added ability to render native Section Index Title scrolling functionality. This exposes a new boolean prop called sectionIndexTitlesEnabled

- Fixed bug I noticed with the allowsMultipleSelection feature where, when set to false, you could only select one element in a section as intended, but selecting an option under a different section would not deselect the original. 

- Fixed a bug in `RNTableView/RNAppGlobals.h` that would cause the build to fail when running on a mac with a case-sensitive file system.