### PR TITLE
allow table view open in editing mode

### DIFF
--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -33,19 +33,19 @@
     NSString *_reactModuleCellReuseIndentifier;
 }
 
--(void)setEditing:(BOOL)editing {
+- (void)setEditing:(BOOL)editing {
+    _editing = editing;
+    
     [self.tableView setEditing:editing animated:YES];
 }
 
--(void) setSeparatorColor:(UIColor *)separatorColor
-{
+- (void)setSeparatorColor:(UIColor *)separatorColor {
     _separatorColor = separatorColor;
 
     [self.tableView setSeparatorColor: separatorColor];
 }
 
--(void)setScrollEnabled:(BOOL)scrollEnabled
-{
+- (void)setScrollEnabled:(BOOL)scrollEnabled {
     _scrollEnabled = scrollEnabled;
 
     [self.tableView setScrollEnabled:scrollEnabled];
@@ -187,6 +187,7 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     _tableView.separatorStyle = self.separatorStyle;
     _tableView.separatorColor = self.separatorColor;
     _tableView.scrollEnabled = self.scrollEnabled;
+    _tableView.editing = self.editing;
     _reactModuleCellReuseIndentifier = @"ReactModuleCell";
     [_tableView registerClass:[RNReactModuleCell class] forCellReuseIdentifier:_reactModuleCellReuseIndentifier];
     [self addSubview:_tableView];


### PR DESCRIPTION
This PR will allow to open TableView already in editing mode, e.g. code like 

```
        <TableView
          editing
          tableViewCellEditingStyle={Consts.CellEditingStyle.Delete}
          style={{ flex: 1 }}
          onPress={() => {}}
        >
          <Section canMove canEdit>
            <Item>Российский рубль</Item>
            <Item>Доллар США</Item>
            <Item>Евро</Item>
            <Item>Фунт стерлингов</Item>
          </Section>
        </TableView>
```

will produce the following right after opening the view:

![screenshot 2017-07-19 13 10 07](https://user-images.githubusercontent.com/1160116/28362059-b32673ac-6c83-11e7-962c-b35b60a8ead9.png)
