### PR TITLE
Crash when loading json

### DIFF
--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -36,7 +36,7 @@
 
 - (void)setEditing:(BOOL)editing {
     _editing = editing;
-    
+
     [self.tableView setEditing:editing animated:YES];
 }
 
@@ -174,7 +174,7 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     NSMutableArray *keys = [NSMutableArray arrayWithCapacity:[_sections count]];
 
     for (NSDictionary *section in _sections){
-        NSString *label = _sections[@"label"] ?: @"";
+        NSString *label = section[@"label"] ?: @"";
         [keys addObject:label];
     }
 

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -174,7 +174,8 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
     NSMutableArray *keys = [NSMutableArray arrayWithCapacity:[_sections count]];
 
     for (NSDictionary *section in _sections){
-        [keys addObject:section[@"label"]];
+        NSString *label = _sections[@"label"] ?: @"";
+        [keys addObject:label];
     }
 
     return keys;


### PR DESCRIPTION
nil section header labels are now replaced with empty string avoiding a crash. This crash was most evident when attempting to load json data that didn't have a label for a section.