### PR TITLE
Fix section index titles always being visible

### DIFF
--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -170,6 +170,10 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 }
 
 - (NSArray *)sectionIndexTitlesForTableView:(UITableView *)tableView {
+    if (!_sectionIndexTitlesEnabled) {
+      return nil;
+    }
+
     // create selected indexes
     NSMutableArray *keys = [NSMutableArray arrayWithCapacity:[_sections count]];
 


### PR DESCRIPTION
As part of this pull request: https://github.com/aksonov/react-native-tableview/pull/134 the ability to show section indexes was added. However there doesn't seem to be a way to turn them off, setting sectionIndexTitlesEnabled to true|false has no effect, they are always enabled.

This fix, makes sure we check the variable that is suppose to turn the feature on/off.