### PR TITLE
Fast-Rendering Issues with `onScroll()`

### DIFF
--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -588,6 +588,11 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 #pragma mark - Scrolling
 
 -(void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    if (!self.onScroll) {
+        // When rendering, `self.tableView.delegate` may be set before `onScroll` is passed in.
+        return;
+    }
+
     self.onScroll(@{
                     @"target": self.reactTag,
                     @"contentOffset": @{

--- a/src/TableView.js
+++ b/src/TableView.js
@@ -36,7 +36,7 @@ class TableView extends React.Component {
     onAccessoryPress: PropTypes.func,
     onWillDisplayCell: PropTypes.func,
     onEndDisplayingCell: PropTypes.func,
-    selectedValue: PropTypes.oneOf([PropTypes.string, PropTypes.number]), // string or integer basically
+    selectedValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]), // string or integer basically
     autoFocus: PropTypes.bool,
     autoFocusAnimate: PropTypes.bool,
     alwaysBounceVertical: PropTypes.bool,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -211,7 +211,7 @@ interface TableViewProps {
   showsHorizontalScrollIndicator?: boolean
   showsVerticalScrollIndicator?: boolean
   moveWithinSectionOnly?: boolean
-  selectedValue?: any
+  selectedValue?: string | number
   json?: string
   filter?: string
   contentInset?: EdgeInsetsPropType


### PR DESCRIPTION
I found issues on my simulator where `self.onScroll()` is unset for the first call or two calls from `UIScrollViewDelegate`, which needs safety checking to be properly handled.

Also...correct PropType validation 🚦