### PR TITLE
Added properties for cell margins and separator insets

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ The following style props are supported:
 * `contentInset`
 * `contentOffset`
 * `scrollIndicatorInsets`
+* `cellLayoutMargins`
+* `cellSeparatorInset`
 
 Colors:
 

--- a/RNTableView/RNTableView.h
+++ b/RNTableView/RNTableView.h
@@ -36,13 +36,16 @@
 @property(nonatomic) float headerHeight;
 @property(nonatomic) BOOL customCells;
 @property(nonatomic) BOOL editing;
-@property(nonatomic) BOOL emptyInsets;
 @property(nonatomic) BOOL moveWithinSectionOnly;
 @property(nonatomic, assign) UIEdgeInsets contentInset;
 @property(nonatomic, assign) CGPoint contentOffset;
 @property(nonatomic, assign) UIEdgeInsets scrollIndicatorInsets;
 @property(nonatomic, assign) BOOL showsHorizontalScrollIndicator;
 @property(nonatomic, assign) BOOL showsVerticalScrollIndicator;
+@property(nonatomic, assign) UIEdgeInsets cellSeparatorInset;
+@property(nonatomic, assign) BOOL hasCellSeparatorInset;
+@property(nonatomic, assign) UIEdgeInsets cellLayoutMargins;
+@property(nonatomic, assign) BOOL hasCellLayoutMargins;
 @property(nonatomic, assign) BOOL canRefresh;
 @property(nonatomic, assign) BOOL refreshing;
 

--- a/RNTableView/RNTableView.m
+++ b/RNTableView/RNTableView.m
@@ -303,21 +303,12 @@ RCT_NOT_IMPLEMENTED(-initWithCoder:(NSCoder *)aDecoder)
 
 -(void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (self.emptyInsets){
-        // Remove separator inset
-        if ([cell respondsToSelector:@selector(setSeparatorInset:)]) {
-            [cell setSeparatorInset:UIEdgeInsetsZero];
-        }
-        
-        // Prevent the cell from inheriting the Table View's margin settings
-        if ([cell respondsToSelector:@selector(setPreservesSuperviewLayoutMargins:)]) {
-            [cell setPreservesSuperviewLayoutMargins:NO];
-        }
-        
-        // Explictly set your cell's layout margins
-        if ([cell respondsToSelector:@selector(setLayoutMargins:)]) {
-            [cell setLayoutMargins:UIEdgeInsetsZero];
-        }
+    if (self.hasCellLayoutMargins && [cell respondsToSelector:@selector(setLayoutMargins:)] && [cell respondsToSelector:@selector(setPreservesSuperviewLayoutMargins:)]) {
+        [cell setPreservesSuperviewLayoutMargins:NO];
+        [cell setLayoutMargins:self.cellLayoutMargins];
+    }
+    if (self.hasCellSeparatorInset && [cell respondsToSelector:@selector(setSeparatorInset:)]) {
+        [cell setSeparatorInset:self.cellSeparatorInset];
     }
     if (self.font){
         cell.detailTextLabel.font = self.font;

--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -41,7 +41,6 @@ RCT_EXPORT_VIEW_PROPERTY(json, NSString)
 RCT_EXPORT_VIEW_PROPERTY(editing, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoFocus, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(autoFocusAnimate, BOOL)
-RCT_EXPORT_VIEW_PROPERTY(emptyInsets, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(filter, NSString)
 RCT_EXPORT_VIEW_PROPERTY(selectedValue, id)
 RCT_EXPORT_VIEW_PROPERTY(filterArgs, NSArray)
@@ -131,6 +130,16 @@ RCT_CUSTOM_VIEW_PROPERTY(showsHorizontalScrollIndicator, BOOL, RNTableView) {
 
 RCT_CUSTOM_VIEW_PROPERTY(showsVerticalScrollIndicator, BOOL, RNTableView) {
     [view setShowsVerticalScrollIndicator:[RCTConvert BOOL:json]];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(cellSeparatorInset, UIEdgeInsets, RNTableView) {
+    view.hasCellSeparatorInset = YES;
+    view.cellSeparatorInset = [RCTConvert UIEdgeInsets:json];
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(cellLayoutMargins, UIEdgeInsets, RNTableView) {
+    view.hasCellLayoutMargins = YES;
+    view.cellLayoutMargins = [RCTConvert UIEdgeInsets:json];
 }
 
 - (NSDictionary *)constantsToExport {

--- a/src/TableView.js
+++ b/src/TableView.js
@@ -98,6 +98,8 @@ class TableView extends React.Component {
     refreshing: PropTypes.bool,
     onRefresh: PropTypes.func,
     canRefresh: PropTypes.bool,
+    cellSeparatorInset: EdgeInsetsPropType,
+    cellLayoutMargins: EdgeInsetsPropType,
   }
 
   static defaultProps = {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -259,7 +259,9 @@ interface TableViewProps {
   onRefresh?(): void
   onAccessoryPress?(event: AccessoryCallBack): void
   onWillDisplayCell?(event: DisplayCallBack): void
-  onEndDisplayingCell?(event: DisplayCallBack): void
+  onEndDisplayingCell?(event: DisplayCallBack): void,
+  cellSeparatorInset: Insets,
+  cellLayoutMargins: Insets
 }
 
 declare class TableView extends React.Component<TableViewProps> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,7 +4,7 @@
 // TypeScript Version: 2.6
 
 import * as React from 'react'
-import { ViewStyle, EdgeInsetsPropType, PointPropType, NativeSyntheticEvent, NativeScrollEvent } from 'react-native'
+import { ViewStyle, Insets, PointPropType, NativeSyntheticEvent, NativeScrollEvent } from 'react-native'
 
 type FontWeight = 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 | 900 | 'bold' | 'normal'
 
@@ -225,9 +225,9 @@ interface TableViewProps {
   selectedValue?: string | number
   json?: string
   filter?: string
-  contentInset?: EdgeInsetsPropType
+  contentInset?: Insets
   contentOffset?: PointPropType
-  scrollIndicatorInsets?: EdgeInsetsPropType
+  scrollIndicatorInsets?: Insets
   textColor?: string
   detailTextColor?: string
   tintColor?: string


### PR DESCRIPTION
This will deprecate the undocumented `emptyInsets` property and replace it with `cellSeparatorInset` and `cellLayoutMargins` to customize the cell's layout margins and separator inset.

Is dependent on #171