### PR TITLE
Removed default tableViewStyle

### DIFF
--- a/src/TableView.js
+++ b/src/TableView.js
@@ -101,7 +101,6 @@ class TableView extends React.Component {
   }
 
   static defaultProps = {
-    tableViewStyle: RNTableViewConsts.Style.Plain,
     tableViewCellStyle: RNTableViewConsts.CellStyle.Subtitle,
     tableViewCellEditingStyle: RNTableViewConsts.CellEditingStyle.Delete,
     separatorStyle: RNTableViewConsts.SeparatorStyle.Line,


### PR DESCRIPTION
Continuation of the discussion on PR #173. This way, the user has to explicitly chose a tableViewStyle, this matches better the UIKit behavior which is to explicitly chose a style and has no style by default.