### PR TITLE
Remove git+ from the repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/aksonov/react-native-tableview.git"
+    "url": "https://github.com/aksonov/react-native-tableview.git"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
`git+` url format is not supported by [cocoapods](https://guides.cocoapods.org/syntax/podspec.html#source). In the current [package.json](https://github.com/aksonov/react-native-tableview/blob/master/package.json#L12), the url is [defaulting to master branch](https://docs.npmjs.com/files/package.json#urls-as-dependencies) as no commit-ish is specified. Removing `git+` allows the users using cocoapods as a dependency manager to work with the library seamlessly. Removal of `git+` from url does not affect any other functionality