### PR TITLE
Use `RCTComponentEvent` for React Native 0.60

### DIFF
--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -12,6 +12,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTFont.h>
 #import <React/RCTUIManager.h>
+#import <React/RCTComponentEvent.h>
 
 @implementation RNTableViewManager
 

--- a/RNTableView/RNTableViewManager.m
+++ b/RNTableView/RNTableViewManager.m
@@ -253,7 +253,10 @@ RCT_CUSTOM_VIEW_PROPERTY(footerFontFamily, NSString, RNTableView)
 
 RCT_EXPORT_METHOD(sendNotification:(NSDictionary *)data)
 {
-    [self.bridge.eventDispatcher sendInputEventWithName:@"onItemNotification" body:data];
+    RCTComponentEvent *event = [[RCTComponentEvent alloc] initWithName:@"onItemNotification"
+                                                               viewTag:nil
+                                                                  body:data];
+    [self.bridge.eventDispatcher sendEvent:event];
 }
 
 RCT_EXPORT_METHOD(scrollTo:(nonnull NSNumber *)reactTag
@@ -276,7 +279,7 @@ RCT_EXPORT_METHOD(startRefreshing:(nonnull NSNumber *)reactTag)
     [self.bridge.uiManager addUIBlock:
      ^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry){
          RNTableView *tableView = viewRegistry[reactTag];
-         
+
          if ([tableView isKindOfClass:[RNTableView class]]) {
              [tableView startRefreshing];
          } else {
@@ -290,7 +293,7 @@ RCT_EXPORT_METHOD(stopRefreshing:(nonnull NSNumber *)reactTag)
     [self.bridge.uiManager addUIBlock:
      ^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry){
          RNTableView *tableView = viewRegistry[reactTag];
-         
+
          if ([tableView isKindOfClass:[RNTableView class]]) {
              [tableView stopRefreshing];
          } else {
@@ -307,7 +310,7 @@ RCT_EXPORT_METHOD(scrollToIndex:(nonnull NSNumber *)reactTag
     [self.bridge.uiManager addUIBlock:
      ^(__unused RCTUIManager *uiManager, NSDictionary *viewRegistry){
          RNTableView *tableView = viewRegistry[reactTag];
-         
+
          if ([tableView isKindOfClass:[RNTableView class]]) {
              [tableView scrollToIndex:index section:section animated:animated];
          } else {


### PR DESCRIPTION
## Summary

React Native 0.60 removes some deprecated stuff -> https://github.com/facebook/react-native/commit/41343f6a7305cc82c412898139c46c01047f3399

## Impact

This will be a breaking change.
